### PR TITLE
V0.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "jokesapp",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "jokesapp",
-      "version": "0.0.2",
+      "version": "0.0.3",
       "dependencies": {
         "@tailwindcss/vite": "^4.1.8",
         "axios": "^1.9.0",
@@ -15,6 +15,7 @@
         "vue-router": "^4.5.0"
       },
       "devDependencies": {
+        "@pinia/testing": "^1.0.1",
         "@playwright/test": "^1.51.1",
         "@tsconfig/node22": "^22.0.1",
         "@types/jsdom": "^21.1.7",
@@ -26,7 +27,6 @@
         "@vue/eslint-config-typescript": "^14.5.0",
         "@vue/test-utils": "^2.4.6",
         "@vue/tsconfig": "^0.7.0",
-        "autoprefixer": "^10.4.21",
         "eslint": "^9.22.0",
         "eslint-plugin-oxlint": "^0.16.0",
         "eslint-plugin-playwright": "^2.2.0",
@@ -35,7 +35,6 @@
         "jsdom": "^26.0.0",
         "npm-run-all2": "^7.0.2",
         "oxlint": "^0.16.0",
-        "postcss": "^8.5.4",
         "prettier": "3.5.3",
         "tailwindcss": "^4.1.8",
         "typescript": "~5.8.0",
@@ -1537,6 +1536,19 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@pinia/testing": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@pinia/testing/-/testing-1.0.1.tgz",
+      "integrity": "sha512-EYnPfoFtbrgkPj4QLiCp8dHgsqmc8fLqmQtTzp760V7enEb5ZOgH5zkwitGhkF7DM+AW3H+btdzkGeD1U3KKiQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/posva"
+      },
+      "peerDependencies": {
+        "pinia": ">=3.0.2"
+      }
     },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
@@ -3115,43 +3127,6 @@
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
-    "node_modules/autoprefixer": {
-      "version": "10.4.21",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.21.tgz",
-      "integrity": "sha512-O+A6LWV5LDHSJD3LjHYoNi4VLsj/Whi7k6zG12xTYaU4cQ8oxQGckXNX8cRHK5yOZ/ppVHe0ZBXGzSV9jXdVbQ==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "dependencies": {
-        "browserslist": "^4.24.4",
-        "caniuse-lite": "^1.0.30001702",
-        "fraction.js": "^4.3.7",
-        "normalize-range": "^0.1.2",
-        "picocolors": "^1.1.1",
-        "postcss-value-parser": "^4.2.0"
-      },
-      "bin": {
-        "autoprefixer": "bin/autoprefixer"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      },
-      "peerDependencies": {
-        "postcss": "^8.1.0"
-      }
-    },
     "node_modules/axios": {
       "version": "1.9.0",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.9.0.tgz",
@@ -4413,19 +4388,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/fraction.js": {
-      "version": "4.3.7",
-      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
-      "integrity": "sha512-ZsDfxO51wGAXREY55a7la9LScWpwv9RxIrYABrlvOFBlH/ShPnrtsXeuUIfXKKOVicNxQ+o8JTbJvjS4M89yew==",
-      "dev": true,
-      "engines": {
-        "node": "*"
-      },
-      "funding": {
-        "type": "patreon",
-        "url": "https://github.com/sponsors/rawify"
-      }
-    },
     "node_modules/fs-extra": {
       "version": "11.3.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
@@ -5618,15 +5580,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/normalize-range": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/normalize-range/-/normalize-range-0.1.2.tgz",
-      "integrity": "sha512-bdok/XvKII3nUpklnV6P2hxtMNrCboOjAcyBuQnWEhO665FwrSNRxU+AqpsyvO6LgGYPspN+lu5CLtw4jPRKNA==",
-      "dev": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/npm-normalize-package-bin": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/npm-normalize-package-bin/-/npm-normalize-package-bin-4.0.0.tgz",
@@ -6107,12 +6060,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/postcss-value-parser": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
-      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
-      "dev": true
     },
     "node_modules/prelude-ls": {
       "version": "1.2.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "jokesapp",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "private": true,
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "vue-router": "^4.5.0"
   },
   "devDependencies": {
+    "@pinia/testing": "^1.0.1",
     "@playwright/test": "^1.51.1",
     "@tsconfig/node22": "^22.0.1",
     "@types/jsdom": "^21.1.7",

--- a/src/components/__tests__/JokeCard.spec.ts
+++ b/src/components/__tests__/JokeCard.spec.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import JokeCard from '@/components/JokeCard.vue'
+
+describe('JokeCard.vue', () => {
+  it('renders joke props', () => {
+    const joke = {
+      id: 1,
+      type: 'general',
+      setup: 'Why did the chicken cross the road?',
+      punchline: 'To get to the other side!',
+    }
+    const wrapper = mount(JokeCard, {
+      props: { joke },
+    })
+    expect(wrapper.text()).toContain(joke.setup)
+    expect(wrapper.text()).toContain(joke.punchline)
+  })
+})

--- a/src/components/__tests__/PaginationNavbar.spec.ts
+++ b/src/components/__tests__/PaginationNavbar.spec.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import PaginationNavbar from '@/components/PaginationNavbar.vue'
+
+describe('PaginationNavbar.vue', () => {
+  it('emits page-changed event when next/prev clicked', async () => {
+    const wrapper = mount(PaginationNavbar, {
+      props: {
+        currentPage: 2,
+        totalItems: 20,
+        pageSize: 5,
+      },
+    })
+    await wrapper.find('button:last-child').trigger('click')
+    expect(wrapper.emitted()['page-changed']).toBeTruthy()
+  })
+})

--- a/src/components/__tests__/SortControl.spec.ts
+++ b/src/components/__tests__/SortControl.spec.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import SortControl from '@/components/SortControl.vue'
+
+describe('SortControl.vue', () => {
+  it('emits sort event when sort option is selected', async () => {
+    const wrapper = mount(SortControl)
+    // Simulate sort event if your component emits it on some action
+    // For example, if you have a select input:
+    const select = wrapper.find('select')
+    if (select.exists()) {
+      await select.setValue('type')
+      expect(wrapper.emitted().sort).toBeTruthy()
+    }
+  })
+})

--- a/src/views/__tests__/HomeView.spec.ts
+++ b/src/views/__tests__/HomeView.spec.ts
@@ -1,11 +1,47 @@
-import { describe, it, expect } from 'vitest'
-
+import { describe, it, expect, vi } from 'vitest'
 import { mount } from '@vue/test-utils'
-import HomeView from '../HomeView.vue'
+import HomeView from '@/views/HomeView.vue'
+import JokeCard from '@/components/JokeCard.vue'
+import PaginationNavbar from '@/components/PaginationNavbar.vue'
+import SortControl from '@/components/SortControl.vue'
+import { createTestingPinia } from '@pinia/testing'
 
-describe('Home view', () => {
-  it('renders properly', () => {
-    const wrapper = mount(HomeView)
-    expect(wrapper.text()).toContain('Jokes')
+describe('HomeView.vue', () => {
+  it('renders SortControl, JokeCard(s), and PaginationNavbar', async () => {
+    const wrapper = mount(HomeView, {
+      global: {
+        plugins: [
+          createTestingPinia({
+            stubActions: false, // Disable actions to avoid needing to mock them
+            createSpy: vi.fn, // Use Vitest's spy function
+            initialState: {
+              jokes: {
+                jokes: [
+                  {
+                    type: 'general',
+                    setup: 'What do you get when you cross a chicken with a skunk?',
+                    punchline: 'A fowl smell!',
+                    id: 1,
+                  },
+                ], // Start with an empty jokes array
+                totalJokes: 1,
+                currentPage: 1,
+                totalPages: 1,
+              },
+            },
+          }),
+        ],
+        stubs: {
+          JokeCard,
+          PaginationNavbar,
+          SortControl,
+        },
+      },
+    })
+
+    expect(wrapper.findComponent(SortControl).exists()).toBe(true)
+    expect(wrapper.findComponent(PaginationNavbar).exists()).toBe(true)
+    // JokeCard is rendered for each joke, but with empty store, none will show
+    expect(wrapper.findComponent(JokeCard).exists()).toBe(true)
   })
 })


### PR DESCRIPTION
Key Changes:

**Version Bump:**

- Upgrades the version in `package.json` and `package-lock.json` from 0.0.2 to 0.0.3.

**Dependency Changes:**

- Adds `@pinia/testing` as a new dev dependency.
- Removes unused dev dependencies: `autoprefixer` and `postcss` (and related packages).
- Updates lockfile accordingly.

**New and Improved Tests:**

- Adds new unit tests for:
  - `JokeCard` component (`src/components/__tests__/JokeCard.spec.ts`)
  - `PaginationNavbar` component (`src/components/__tests__/PaginationNavbar.spec.ts`)
  - `SortControl` component (`src/components/__tests__/SortControl.spec.ts`)
- Expands and refactors tests for `HomeView` in `src/views/__tests__/HomeView.spec.ts`:
  - Now tests for the presence of `JokeCard`, `PaginationNavbar`, and `SortControl` components.
  - Uses `@pinia/testing` for mocking store state.